### PR TITLE
Handle error when getting userAgent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ export class ExpoMixpanelAnalytics {
         this.identify(this.clientId);
         this._flush();
       });
-    });
+    }).catch(error => console.log(error));
   }
 
   register(props: any) {


### PR DESCRIPTION
This will fix unhandled promise rejection warnings

1.  TypeError: null is not an object (evaluating '_expoConstants.default.manifest.name')
2.  Error: The WKWebview was invalidated