### PR TITLE
Ability to attach a custom userAgent on instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ import ExpoMixpanelAnalytics from '@benawad/expo-mixpanel-analytics';
 
 ## Usage
 ```
-const analytics = new ExpoMixpanelAnalytics("5224da5bbbed3fdeaad0911820f1bf2x");
+const analytics = new ExpoMixpanelAnalytics(
+    "5224da5bbbed3fdeaad0911820f1bf2x",
+    // Optional
+    { userAgent: 'Custom useragent' }
+);
 
 analytics.identify("13793");
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,32 +39,16 @@ export class ExpoMixpanelAnalytics {
     this.osVersion = Platform.Version;
     this.superProps;
 
-    Constants.getWebViewUserAgentAsync().then(userAgent => {
-      this.userAgent = userAgent;
-      this.appName = Constants.manifest.name;
-      this.appId = Constants.manifest.slug;
-      this.appVersion = Constants.manifest.version;
-      this.screenSize = `${width}x${height}`;
-      this.deviceName = Constants.deviceName;
-      if (isIosPlatform && Constants.platform && Constants.platform.ios) {
-        this.platform = Constants.platform.ios.platform;
-        this.model = Constants.platform.ios.model;
-      } else {
-        this.platform = "android";
-      }
-
-      AsyncStorage.getItem(ASYNC_STORAGE_KEY, (_, result) => {
-        if (result) {
-          try {
-            this.superProps = JSON.parse(result) || {};
-          } catch {}
-        }
-
-        this.ready = true;
-        this.identify(this.clientId);
-        this._flush();
+    // Attach custom userAgent if provided. Otherwise, grab WebView userAgent
+    if (options.userAgent) {
+      this.userAgent = options.userAgent;
+      this._setupDeviceInfo();
+    } else {
+      Constants.getWebViewUserAgentAsync().then((userAgent) => {
+        this.userAgent = userAgent;
+        this._setupDeviceInfo();
       });
-    });
+    }
   }
 
   register(props: any) {
@@ -122,6 +106,32 @@ export class ExpoMixpanelAnalytics {
   }
 
   // ===========================================================================================
+
+  _setupDeviceInfo() {
+    this.appName = Constants.manifest.name;
+    this.appId = Constants.manifest.slug;
+    this.appVersion = Constants.manifest.version;
+    this.screenSize = `${width}x${height}`;
+    this.deviceName = Constants.deviceName;
+    if (isIosPlatform && Constants.platform && Constants.platform.ios) {
+      this.platform = Constants.platform.ios.platform;
+      this.model = Constants.platform.ios.model;
+    } else {
+      this.platform = "android";
+    }
+
+    AsyncStorage.getItem(ASYNC_STORAGE_KEY, (_, result) => {
+      if (result) {
+        try {
+          this.superProps = JSON.parse(result) || {};
+        } catch {}
+      }
+
+      this.ready = true;
+      this.identify(this.clientId);
+      this._flush();
+    });
+  }
 
   _flush() {
     if (this.ready) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,10 @@ const MIXPANEL_API_URL = "https://api.mixpanel.com";
 const ASYNC_STORAGE_KEY = "mixpanel:super:props";
 const isIosPlatform = Platform.OS === "ios";
 
+export type Options = {
+  userAgent?: string;
+};
+
 export class ExpoMixpanelAnalytics {
   ready = false;
   token: string;
@@ -25,7 +29,7 @@ export class ExpoMixpanelAnalytics {
   queue: any[];
   superProps: any = {};
 
-  constructor(token) {
+  constructor(token, options: Options) {
     this.ready = false;
     this.queue = [];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,18 @@ export class ExpoMixpanelAnalytics {
     this.osVersion = Platform.Version;
     this.superProps;
 
+    AsyncStorage.getItem(ASYNC_STORAGE_KEY, (_, result) => {
+      if (result) {
+        try {
+          this.superProps = JSON.parse(result) || {};
+        } catch {}
+      }
+
+      this.ready = true;
+      this.identify(this.clientId);
+      this._flush();
+    });
+
     // Attach custom userAgent if provided. Otherwise, grab WebView userAgent
     if (options.userAgent) {
       this.userAgent = options.userAgent;
@@ -119,18 +131,6 @@ export class ExpoMixpanelAnalytics {
     } else {
       this.platform = "android";
     }
-
-    AsyncStorage.getItem(ASYNC_STORAGE_KEY, (_, result) => {
-      if (result) {
-        try {
-          this.superProps = JSON.parse(result) || {};
-        } catch {}
-      }
-
-      this.ready = true;
-      this.identify(this.clientId);
-      this._flush();
-    });
   }
 
   _flush() {


### PR DESCRIPTION
## Purpose
The module calls `getWebbviewUserAgentAsync` from `expo-constants`, which throws the exception "WKWebView was invalidated error" if already previously invoked.

For my use case, I am using both Mixpanel via this module and Google Analytics via `expo-analytics`. I would like to get the userAgent once and supply it to both modules on instantiation.

## Approach
The `ExpoMixpanelAnalytics` now takes an `Options` parameter with an optional `userAgent` field. If a custom `userAgent` is provided, it will be attached to the class field. Otherwise, `getWebbviewUserAgentAsync` will be invoked.

## Learning

https://forums.expo.io/t/unhandled-promise-rejection-error-the-wkwebview-was-invalidated/25044/4
