### PR TITLE
Fix AsyncStorage & expo-constants 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@benawad/expo-mixpanel-analytics",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "description": "Mixpanel integration for use with React Native apps built on Expo.",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -30,6 +30,7 @@
   },
   "peerDependencies": {
     "expo-constants": "^5.0.1",
+    "expo-device": "^4.0.3",
     "react": "16.5.2",
     "react-native": "https://github.com/expo/react-native/archive/sdk-32.0.0.tar.gz"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@benawad/expo-mixpanel-analytics",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Mixpanel integration for use with React Native apps built on Expo.",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -25,6 +25,7 @@
     "url": "https://github.com/codekadiya/expo-mixpanel-analytics/issues"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "1",
     "buffer": "^5.2.1"
   },
   "peerDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Platform, Dimensions } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import Constants from "expo-constants";
+import * as Device from "expo-device";
 import { Buffer } from "buffer";
 
 const { width, height } = Dimensions.get("window");
@@ -42,10 +43,10 @@ export class ExpoMixpanelAnalytics {
       this.appId = Constants.manifest.slug;
       this.appVersion = Constants.manifest.version;
       this.screenSize = `${width}x${height}`;
-      this.deviceName = Constants.deviceName;
-      if (isIosPlatform && Constants.platform && Constants.platform.ios) {
-        this.platform = Constants.platform.ios.platform;
-        this.model = Constants.platform.ios.model;
+      this.deviceName = Device.deviceName;
+      if (isIosPlatform && Device.modelId && Device.modelName) {
+        this.platform = Device.modelId;
+        this.model = Device.modelName;
       } else {
         this.platform = "android";
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,9 @@ export class ExpoMixpanelAnalytics {
       this.appId = Constants.manifest.slug;
       this.appVersion = Constants.manifest.version;
       this.screenSize = `${width}x${height}`;
-      this.deviceName = Device.deviceName;
+      if (Device.deviceName !== null) {
+        this.deviceName = Device.deviceName;
+      }
       if (isIosPlatform && Device.modelId && Device.modelName) {
         this.platform = Device.modelId;
         this.model = Device.modelName;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import { Platform, Dimensions, AsyncStorage } from "react-native";
+import { Platform, Dimensions } from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import Constants from "expo-constants";
 import { Buffer } from "buffer";
 
@@ -35,7 +36,7 @@ export class ExpoMixpanelAnalytics {
     this.osVersion = Platform.Version;
     this.superProps;
 
-    Constants.getWebViewUserAgentAsync().then(userAgent => {
+    Constants.getWebViewUserAgentAsync().then((userAgent) => {
       this.userAgent = userAgent;
       this.appName = Constants.manifest.name;
       this.appId = Constants.manifest.slug;
@@ -73,7 +74,7 @@ export class ExpoMixpanelAnalytics {
   track(name: string, props?: any) {
     this.queue.push({
       name,
-      props
+      props,
     });
     this._flush();
   }
@@ -132,7 +133,7 @@ export class ExpoMixpanelAnalytics {
     if (this.userId) {
       const data = {
         $token: this.token,
-        $distinct_id: this.userId
+        $distinct_id: this.userId,
       };
       data[`$${operation}`] = props;
 
@@ -145,8 +146,8 @@ export class ExpoMixpanelAnalytics {
       event: event.name,
       properties: {
         ...(event.props || {}),
-        ...this.superProps
-      }
+        ...this.superProps,
+      },
     };
     if (this.userId) {
       data.properties.distinct_id = this.userId;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@react-native-async-storage/async-storage@1":
+  version "1.15.14"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.15.14.tgz#8165d3f78798b46e693169795b62e40142064273"
+  integrity sha512-eJF2horabXazwszCyyXDe4w7sBSWlB0WPA8akKXuN2n7WXKHYeQJPN41lS9OahrhSZuZwqftNFE9VWgPXA8wyA==
+  dependencies:
+    merge-options "^3.0.4"
+
 "@types/expo@^32.0.10":
   version "32.0.10"
   resolved "https://registry.yarnpkg.com/@types/expo/-/expo-32.0.10.tgz#ae15e428bb4dcfcb432d9bfead0de7a563c59e98"
@@ -108,6 +115,18 @@ inherits@2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
+
+is-plain-obj@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
+  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
+
+merge-options@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-3.0.4.tgz#84709c2aa2a4b24c1981f66c179fe5565cc6dbb7"
+  integrity sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==
+  dependencies:
+    is-plain-obj "^2.1.0"
 
 minimatch@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
Fixes the following warnings "AsyncStorage has been extracted from react-native core and will be removed in a future release. It can now be installed and imported from '@react-native-async-storage/async-storage' instead of 'react-native'. See https://github.com/react-native-async-storage/async-storage" & "Constants.platform.ios.model has been deprecated in favor of expo-device's Device.modelName property. This API will be removed in SDK 45."